### PR TITLE
Fix Youtube svg icon

### DIFF
--- a/images/youtube-icon.svg
+++ b/images/youtube-icon.svg
@@ -1,4 +1,0 @@
-<svg fill="#FFFFFF" height="36" viewBox="0 0 24 24" width="36" xmlns="http://www.w3.org/2000/svg">
-    <path d="M19 7h-8v6h8V7zm2-4H3c-1.1 0-2 .9-2 2v14c0 1.1.9 1.98 2 1.98h18c1.1 0 2-.88 2-1.98V5c0-1.1-.9-2-2-2zm0 16.01H3V4.98h18v14.03z"/>
-    <path d="M0 0h24v24H0z" fill="none"/>
-</svg>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -54,10 +54,14 @@ function shower() {
 	        pipButton.title = 'PiP Mode';
 	
 	        /** @type {Object} The icon shown in the PiP button */
-	        pipImage = document.createElement('img');
-	        pipImage.src = safari.extension.baseURI + 'images/' + currentResource.name + '-icon.svg';
-	
-	        pipButton.appendChild(pipImage);
+            if (currentResource.name == 'youtube') { 
+                // svg must be inserted inline, otherwise youtube css style properties won't be inherited
+                pipButton.innerHTML = '<svg version="1.1" viewBox="0 0 36 36" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use class="ytp-svg-shadow" xlink:href="#ytp-svg-90"></use><path class="ytp-svg-fill" d="M31,21v7H19v-7H31z M9,11h18v8h2v-8c0-1.1-0.9-2-2-2H9c-1.1,0-2,0.9-2,2v12c0,1.1,0.9,2,2,2h8v-2H9V11zM15,15.4l-3.6-3.5L10,13.3l3.7,3.7H11v2h4h2v-2v-4h-2V15.4z" id="ytp-svg-90"></path></svg>';
+            } else {
+                pipImage = document.createElement('img');
+                pipImage.src = safari.extension.baseURI + 'images/' + currentResource.name + '-icon.svg';
+                pipButton.appendChild(pipImage);                
+            }
 	        
 	        pipButton.addEventListener('click', function (event) {
 	            event.preventDefault();
@@ -78,7 +82,12 @@ function shower() {
 	// 	        document.body.appendChild(pipButton);
 		        document.querySelector('.player-status').appendChild(pipButton);
 	        } else if (controlsWrapper && 0 === controlsWrapper.querySelectorAll('.pip-button').length) {
-	            controlsWrapper.appendChild(pipButton);
+                if (currentResource.name == 'youtube') {
+                    // insert between airplay and fullscreen icon
+                    controlsWrapper.insertBefore(pipButton, controlsWrapper.childNodes[controlsWrapper.childNodes.length-1]);
+                } else {
+                    controlsWrapper.appendChild(pipButton);
+                }
 	        } else if (currentResource.name == 'weather' && document.body.querySelectorAll('.pip-button').length < 1) {
 	            document.querySelector('.akamai-controls .akamai-control-bar').appendChild(pipButton);
 	   


### PR DESCRIPTION
I have redesigned and moved the Youtube PiP icon between AirPlay and fullscreen icons, to maintain visual consistency. 

<img width="235" alt="screen shot 2017-04-20 at 5 43 34 pm" src="https://cloud.githubusercontent.com/assets/3258110/25239908/b8d10d2c-25f1-11e7-9202-66ce2f6c3b74.png">

SVG must be inserted inline, otherwise it won't inherit youtube css styling. See this gist for explanation of the issue https://gist.github.com/chriscoyier/6085a237571a3abe315c

This approach also solves the full screen icon scaling problem.